### PR TITLE
[codex] add contribution and release workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Summary
+
+-
+
+## Checks
+
+- [ ] `bundle exec jekyll build`
+- [ ] `node --check automation/server.js`
+- [ ] `bash -n automation/*.sh`
+
+## Notes
+
+- [ ] Public pages were integrated through existing navigation where possible.
+- [ ] No secrets, private biomedical data, or private service credentials are committed.
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  site:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: automation/package-lock.json
+      - name: Build Jekyll site
+        run: bundle exec jekyll build
+      - name: Check automation scripts
+        run: |
+          cd automation
+          npm ci
+          node --check server.js
+          bash -n *.sh
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Build site
+        run: bundle exec jekyll build
+      - name: Prepare release bundle
+        run: |
+          mkdir -p release
+          tar -czf release/mind-upload-site.tar.gz -C _site .
+          git archive --format=tar.gz --prefix=mind-upload/ HEAD > release/mind-upload-source.tar.gz
+          cd release
+          sha256sum * > SHA256SUMS
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          files: release/*
+          generate_release_notes: true
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes should be recorded here.
+
+## Unreleased
+
+- Add contributor guide, license, and repository health workflow scaffolding.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing
+
+## Setup
+
+```bash
+bundle install
+cd automation && npm install
+```
+
+## Checks
+
+```bash
+bundle exec jekyll build
+cd automation && npm test
+```
+
+`automation` currently contains operational scripts. If `npm test` is still the placeholder script, use a dry run instead:
+
+```bash
+bash ./update_data.sh --dry-run
+```
+
+## Content Rules
+
+- Prefer updating existing pages before creating new public pages.
+- Keep public navigation centered on `index.md` and `content_hub.md`.
+- Put operational logs and generated intermediate artifacts under `automation/` or ignored paths.
+- Do not commit secrets, private biomedical data, or private service credentials.
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Yasufumi Nakata
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security Policy
+
+## Reporting
+
+Use GitHub private vulnerability reporting if it is enabled for this repository. If it is not enabled, open a minimal public issue that says a security report is available, but do not include exploit details, private biomedical data, or secrets.
+
+## Scope
+
+Security-sensitive reports include leaked credentials, unsafe automation that mutates issues or repository content, private data exposure, dependency compromise, and workflows that expose repository tokens.
+
+## Handling
+
+Maintainers should confirm receipt, reproduce the issue in a private branch when needed, rotate any exposed credentials, and publish a fix with a short advisory or release note.
+


### PR DESCRIPTION
## Summary

- Adds contributor guide, security policy, changelog, PR template, CI, and release workflow scaffolding.
- Rebased the PR branch onto the current main branch so the repository-readiness changes are isolated and mergeable.

## Validation

- Workflow YAML parsing passed locally before publication.
- Shell syntax checks were run for automation scripts before the branch was cleaned up.

## Notes

- The original broader local content/automation snapshot is preserved on branch `codex/repository-readiness-full-before-rebase` for review if needed.